### PR TITLE
Improved performance of loading embedding matrix

### DIFF
--- a/asr/__init__.py
+++ b/asr/__init__.py
@@ -1,5 +1,6 @@
 from asr.base import ReviewSimulate, ReviewOracle
 from asr.review import review, review_oracle, review_simulate
 from asr.utils import load_data, text_to_features
+from asr.models.embedding import load_embedding, sample_embedding
 
 __version__ = "0.0.1"

--- a/asr/models/embedding.py
+++ b/asr/models/embedding.py
@@ -1,9 +1,96 @@
-"""Script to create the memory of an embeeding layer."""
+from multiprocessing import Process, Queue, cpu_count
 
 import numpy as np
 
 
-def load_embedding(fp, verbose=1):
+def _embedding_reader(filename, input_queue, block_size=1000):
+    """ Process that reads the word embeddings from a file.
+
+    Parameters
+    ----------
+    filename: str
+        File of trained embedding vectors.
+    input_queue: Queue
+        Queue to store jobs in.
+    block_size: int
+        Number of lines for each job.
+    """
+
+    with open(filename, 'r', encoding='utf-8', newline='\n') as f:
+        # Throw away the first line, since we don't care about the dimensions.
+        f.readline()
+
+        i_line = 0
+        buffer = []
+        # Read the embedding file line by line.
+        for line in f:
+            i_line += 1
+            buffer.append(line)
+            # If the buffer is full, write it to the queue.
+            if i_line == block_size:
+                input_queue.put(buffer)
+                i_line = 0
+                buffer = []
+        if i_line > 0:
+            input_queue.put(buffer)
+
+    # Put the string "DONE" in the queue, to ensure that the
+    # worker processes finish.
+
+    input_queue.put("DONE")
+
+
+def _embedding_worker(input_queue, output_queue, emb_vec_dim, word_index=None):
+    """ Process that reads the word embeddings from a file.
+
+    Parameters
+    ----------
+    input_queue: Queue
+        Queue in which the jobs are submitted.
+    output_queue: Queue
+        Queue to store the embedding in dictionary form.
+    emb_vec_dim: int
+        Dimension of each embedding vector.
+    word_index: dict
+        Dictionary of the sample embedding.
+    """
+
+    embedding_dict = {}
+    badInput = False
+    badValues = {}
+    while not badInput:
+        buffer = input_queue.get()
+        if buffer == "DONE":
+            break
+
+        for line in buffer:
+            values = line.split(' ')
+
+            if len(values) != emb_vec_dim + 2:
+                badInput = True
+                badValues = values
+                break
+
+            word = values[0]
+            if word_index is not None and word not in word_index:
+                continue
+            coefs = values[1:emb_vec_dim + 1]
+
+            # store the results
+            embedding_dict[word] = np.asarray(coefs, dtype=np.float32)
+
+    # We removed the "DONE" from the input queue, so put it back in for
+    # the other processes.
+    input_queue.put("DONE")
+
+    # Store the results in the output queue
+    if badInput:
+        output_queue.put({"ErrorBadInputValues": badValues})
+    else:
+        output_queue.put(embedding_dict)
+
+
+def load_embedding(fp, word_index=None, n_jobs=None, verbose=1):
     """Load embedding matrix from file.
 
     The embedding matrix needs to be stored in the
@@ -13,8 +100,13 @@ def load_embedding(fp, verbose=1):
     ----------
     fp: str
         File path of the trained embedding vectors.
+    word_index: dict
+        Sample word embeddings.
+    n_jobs: int
+        Number of processes to parse the embedding (+1 process for reading).
     verbose: int
         The verbosity. Default 1.
+
 
     Returns
     -------
@@ -23,27 +115,50 @@ def load_embedding(fp, verbose=1):
         the weights as values.
     """
 
-    embedding = {}
+    # Maximum number of jobs in the queue.
+    queue_size = 500
+
+    # Set the number of reader processes to use.
+    if n_jobs is None:
+        n_jobs = 1
+    elif n_jobs == -1:
+        n_jobs = cpu_count()-1
+
+    input_queue = Queue(queue_size)
+    output_queue = Queue()
 
     with open(fp, 'r', encoding='utf-8', newline='\n') as f:
+        n_words, emb_vec_dim = list(map(int, f.readline().split(' ')))
 
-        n, d = list(map(int, f.readline().split(' ')))
+    if verbose == 1:
+        print(f"Reading {n_words} vectors with {emb_vec_dim} dimensions.")
 
-        if verbose == 1:
-            print(f"Reading {n} vectors with {d} dimensions.")
+    embedding = {}
 
-        for i, line in enumerate(f):
+    worker_procs = []
+    for _ in range(n_jobs):
+        p = Process(
+            target=_embedding_worker,
+            args=(input_queue, output_queue, emb_vec_dim, word_index),
+            daemon=True)
+        worker_procs.append(p)
 
-            # split word and weights
-            values = line.split(' ')
-            if len(values) != d + 2:
-                raise ValueError("Check values: %s" % values)
+    # Start workers.
+    for i in range(n_jobs):
+        worker_procs[i].start()
+    _embedding_reader(fp, input_queue)
 
-            word = values[0]
-            coefs = values[1:d + 1]
+    # Merge dictionaries of workers
+    for _ in range(n_jobs):
+        embedding.update(output_queue.get())
 
-            # store the results
-            embedding[word] = np.asarray(coefs, dtype=np.float32)
+    # Join workers
+    for i in range(n_jobs):
+        worker_procs[i].join()
+
+    if "ErrorBadInputValues" in embedding:
+        badValues = embedding["ErrorBadInputValues"]
+        raise ValueError(f"Check embedding matrix, bad format: {badValues}")
 
     if verbose == 1:
         print(f"Found {len(embedding)} word vectors.")
@@ -70,13 +185,14 @@ def sample_embedding(embedding, word_index, verbose=1):
         numpy array and a list with the corresponding words.
     """
 
-    n, d = len(word_index), len(next(iter(embedding.values())))
+    n_words, emb_vec_dim = len(word_index), len(next(iter(embedding.values())))
 
     if verbose == 1:
-        print(f"Creating matrix with {n}+1 vectors with {d} dimensions.")
+        print(f"Creating matrix with {n_words}+1 vectors with {emb_vec_dim} \
+        dimensions.")
 
     # n+1 because 0 is preserved in the tokenizing process.
-    embedding_matrix = np.zeros((n + 1, d))
+    embedding_matrix = np.zeros((n_words + 1, emb_vec_dim))
 
     for word, i in word_index.items():
 

--- a/asr/review.py
+++ b/asr/review.py
@@ -43,7 +43,7 @@ def _load_embedding_matrix(fp, word_index):
 
     from asr.models.embedding import load_embedding, sample_embedding
 
-    embedding = load_embedding(fp)
+    embedding = load_embedding(fp, word_index=word_index)
     return sample_embedding(embedding, word_index)
 
 

--- a/test/test_embedding.py
+++ b/test/test_embedding.py
@@ -1,0 +1,175 @@
+import string
+import random
+import os
+import urllib.request
+
+from asr.models.embedding import load_embedding, sample_embedding
+
+
+def random_words(n_words=1000):
+    """ Generator of random (ascii) words.
+
+    Parameters
+    ----------
+    n_words: int
+        Number of words to generate
+
+    Returns
+    -------
+
+    str:
+        List of words
+    """
+
+    word_dict = {}
+    i = 0
+    # Generate words until we have enough.
+    while len(word_dict) < n_words:
+        n_letters = random.randint(1, 10)
+        new_word = ""
+        for _ in range(n_letters):
+            new_word += random.choice(string.ascii_letters)
+        if new_word not in word_dict:
+            word_dict[new_word] = i
+            i += 1
+    return list(word_dict)
+
+
+def random_sample_embedding(words, n_samples=200):
+    """ Generator of sampled embeddings.
+
+    Parameters
+    ----------
+    words: str
+        List of words to sample from; len(words) >= n_samples.
+    n_samples: int
+        Number of samples to take
+
+    Returns
+    -------
+    dict:
+        Dictionary containing sampled words as keys and order as values.
+    """
+
+    keys = random.sample(words, n_samples)
+    order = random.sample(range(1, n_samples+1), n_samples)
+    return dict(zip(keys, order))
+
+
+def random_embedding(words, emb_vec_dim=300):
+    """ Generator of random embedding.
+
+    Parameters
+    ----------
+    words: str
+        List of words to generate embedding for.
+    emb_vec_dim: int
+       Dimension of embedding vectors.
+
+    Returns
+    -------
+    dict:
+        Random embedding dictionary for all input words.
+    """
+    full_embedding = {}
+    for word in words:
+        new_rand = [random.random() for _ in range(emb_vec_dim)]
+        full_embedding[word] = new_rand
+    return full_embedding
+
+
+def write_random_embedding(full_embedding, tmpfile):
+    """ Write an embedding to a file.
+
+    Parameters
+    ----------
+    tmpfile: str
+        Temporary file created by pytest.
+    full_embedding: dict
+        Embedding without sampling.
+    """
+
+    n_words = len(full_embedding)
+    emb_vec_dim = len(full_embedding[list(full_embedding)[0]])
+    with open(tmpfile, "w") as f:
+        f.write(f"{n_words} {emb_vec_dim}\n")
+        for word in list(full_embedding):
+            f.write(word+" ")
+            new_rand_str = [str(x) for x in full_embedding[word]]
+            # Add extra space at the end of the line for compatibility.
+            f.write(" ".join(new_rand_str)+" \n")
+
+
+def check_embedding(emb, full_embedding, n_samples, emb_vec_dim):
+    """ Do the checking for the loaded embedding.
+
+    Parameters
+    ----------
+    emb: dict
+        Embedding read from a file, potentially subsampled.
+    full_embedding: dict
+        Embedding as created in the unit test directly.
+    n_samples: int
+        Number of samples taken, if not sampled n_samples == n_words.
+    emb_vec_dim: int
+        Dimension of the embedding vectors.
+    """
+    assert len(emb) == n_samples
+    for key in emb:
+        assert emb[key].size == emb_vec_dim
+        for i in range(emb[key].size):
+            assert abs(emb[key][i] - full_embedding[key][i]) < 1e-5
+    assert isinstance(emb, (dict,))
+
+
+def test_load_embedding(tmpdir):
+    """ Unit test for load_embedding function. """
+    n_words = 100
+    n_samples = 30
+    emb_vec_dim = 133
+
+    # Generate embedding.
+    words = random_words(n_words)
+    word_index = random_sample_embedding(words, n_samples)
+    tmpfile = os.path.join(tmpdir, "emb.dat")
+    full_embedding = random_embedding(words, emb_vec_dim)
+
+    write_random_embedding(full_embedding, tmpfile)
+
+    # Test with one worker process, no sampling.
+    emb1 = load_embedding(tmpfile, word_index=None, n_jobs=1, verbose=0)
+    check_embedding(emb1, full_embedding, n_words, emb_vec_dim)
+
+    # Test with all cores, sampling.
+    emb2 = load_embedding(tmpfile, word_index, n_jobs=-1, verbose=0)
+    check_embedding(emb2, full_embedding, n_samples, emb_vec_dim)
+
+    # Test with 3+1 cores, sampling.
+    emb3 = load_embedding(tmpfile, word_index, n_jobs=3, verbose=0)
+    check_embedding(emb3, full_embedding, n_samples, emb_vec_dim)
+
+
+def test_sample_embedding():
+    """ Unit test for sample_embedding """
+    n_words = 100
+    n_samples = 30
+    emb_vec_dim = 133
+
+    # Generate embedding.
+    words = random_words(n_words)
+    word_index = random_sample_embedding(words, n_samples)
+    full_embedding = random_embedding(words, emb_vec_dim)
+    emb_matrix = sample_embedding(full_embedding, word_index, verbose=0)
+
+    assert emb_matrix.shape == (n_samples+1, emb_vec_dim)
+    for key in word_index:
+        i_row = word_index[key]
+        for i in range(emb_vec_dim):
+            assert emb_matrix[i_row][i] == full_embedding[key][i]
+
+
+def test_embedding_link():
+    """ Test if wikipedia embedding still exists. """
+    url = "https://dl.fbaipublicfiles.com" \
+          "/fasttext/vectors-crawl/cc.en.300.vec.gz"
+    assert urllib.request.urlopen(url).getcode() == 200


### PR DESCRIPTION
Use Queue's from the multiprocessing library to speed up the loading times of the embedding layer. Also, use the knowledge of the sampling to not having to load the whole matrix into memory.

On a MacBook Pro Retina 2012 there is a 10x speed up, now loading in approximately 30s.