### PR TITLE
Add functions to automate downloading embedding files

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,35 @@ next to this repository. Now you can debug code with the code below:
 python -m asr oracle ../automated-systematic-review-simulations/pickle/ptsd_vandeschoot_words_20000.pkl --n_instances 5
 ```
 
+### Embedding files
+
+Embedding files contains pretrained model weights. The weights are used as
+prior knowledge of the neural network. By default, these weights are stored in
+the users `~/asr_data` folder. You can download embedding files with the
+following command:
+
+```python
+from asr.models.embedding import download_embedding
+
+download_embedding()
+```
+
+One can set the environment variable to change the default folder.
+
+```
+import os
+
+from asr.models.embedding import download_embedding
+
+# set the environment variable
+os.environ['ASR_DATA'] = "~/my_asr_embedding_files"
+
+# download the files
+download_embedding()
+
+```
+
+
 ## Publications
 
 - Dutch newspaper NRC on this project ["Software vist de beste artikelen uit een bibliotheek van duizenden."](https://www.nrc.nl/nieuws/2019/01/14/software-vist-de-beste-artikelen-eruit-a3628952)

--- a/asr/models/embedding.py
+++ b/asr/models/embedding.py
@@ -3,6 +3,7 @@ import io
 import os
 import shutil
 from multiprocessing import Process, Queue, cpu_count
+from pathlib import Path
 from urllib.request import urlopen
 
 import numpy as np
@@ -126,7 +127,7 @@ def download_embedding(url=EMBEDDING_EN['url'], name=EMBEDDING_EN['name'],
     if data_home is None:
         data_home = get_data_home()
 
-    out_fp = os.path.join(data_home, name)
+    out_fp = Path(data_home, name)
 
     if verbose:
         print(f'download {url}')

--- a/asr/review.py
+++ b/asr/review.py
@@ -9,6 +9,7 @@ import sys
 import warnings
 import argparse
 import pickle
+from pathlib import Path
 
 import pandas
 
@@ -99,8 +100,14 @@ def review(dataset,
         if isinstance(dataset, str) & (model.lower() == 'lstm'):
 
             if embedding is None:
-                download_embedding(verbose=verbose)
-                embedding = os.path.join(get_data_home(), EMBEDDING_EN["name"])
+                embedding = Path(
+                    get_data_home(), 
+                    EMBEDDING_EN["name"]
+                ).expanduser()
+
+                if not embedding.exists():
+                    download_embedding(verbose=verbose)
+
 
             # create features and labels
             X, word_index = text_to_features(texts)

--- a/asr/review.py
+++ b/asr/review.py
@@ -9,6 +9,7 @@ import sys
 import warnings
 import argparse
 import pickle
+import time
 from pathlib import Path
 
 import pandas
@@ -101,13 +102,15 @@ def review(dataset,
 
             if embedding is None:
                 embedding = Path(
-                    get_data_home(), 
+                    get_data_home(),
                     EMBEDDING_EN["name"]
                 ).expanduser()
 
                 if not embedding.exists():
+                    print("Warning: will start to download large"
+                          "embedding file in 10 seconds.")
+                    time.sleep(10)
                     download_embedding(verbose=verbose)
-
 
             # create features and labels
             X, word_index = text_to_features(texts)

--- a/asr/review.py
+++ b/asr/review.py
@@ -19,6 +19,8 @@ from asr.config import MODUS
 from asr.query_strategies import random_sampling, uncertainty_sampling
 from asr.ascii import ASCII_TEA
 from asr.types import is_pickle, convert_list_type
+from asr.models.embedding import download_embedding, EMBEDDING_EN
+from asr.utils import get_data_home
 
 # constants
 EPOCHS = 3
@@ -94,7 +96,11 @@ def review(dataset,
         texts, labels = load_data(dataset)
 
         # get the model
-        if isinstance(dataset, str) & (model.lower() == 'lstm') & (embedding is not None):
+        if isinstance(dataset, str) & (model.lower() == 'lstm'):
+
+            if embedding is None:
+                download_embedding(verbose=verbose)
+                embedding = os.path.join(get_data_home(), EMBEDDING_EN["name"])
 
             # create features and labels
             X, word_index = text_to_features(texts)

--- a/asr/utils.py
+++ b/asr/utils.py
@@ -1,10 +1,13 @@
 # Cpython dependencies
-import pathlib
 import json
+import pathlib
+import shutil
+from os import environ, makedirs, path
 
 # external dependencies
-import pandas as pd
 import numpy as np
+
+import pandas as pd
 
 
 def load_data(fp):
@@ -158,3 +161,43 @@ class Logger(object):
 
         with fp.open('w') as outfile:
             json.dump(self._log_dict, outfile)
+
+
+def get_data_home(data_home=None):
+    """Return the path of the ASR data dir.
+
+    This folder is used by some large dataset loaders to avoid downloading the
+    data several times.
+    By default the data dir is set to a folder named 'asr_data' in the
+    user home folder.
+    Alternatively, it can be set by the 'ASR_DATA' environment
+    variable or programmatically by giving an explicit folder path. The '~'
+    symbol is expanded to the user home folder.
+    If the folder does not already exist, it is automatically created.
+
+    Parameters
+    ----------
+    data_home : str | None
+        The path to scikit-learn data dir.
+
+    """
+    if data_home is None:
+        data_home = environ.get('ASR_DATA',
+                                path.join('~', 'asr_data'))
+    data_home = path.expanduser(data_home)
+    if not path.exists(data_home):
+        makedirs(data_home)
+    return data_home
+
+
+def clear_data_home(data_home=None):
+    """Delete all the content of the data home cache.
+
+    Parameters
+    ----------
+    data_home : str | None
+        The path to scikit-learn data dir.
+
+    """
+    data_home = get_data_home(data_home)
+    shutil.rmtree(data_home)

--- a/asr/utils.py
+++ b/asr/utils.py
@@ -1,8 +1,8 @@
 # Cpython dependencies
 import json
-import pathlib
+from os import environ
+from pathlib import Path
 import shutil
-from os import environ, makedirs, path
 
 # external dependencies
 import numpy as np
@@ -183,10 +183,12 @@ def get_data_home(data_home=None):
     """
     if data_home is None:
         data_home = environ.get('ASR_DATA',
-                                path.join('~', 'asr_data'))
-    data_home = path.expanduser(data_home)
-    if not path.exists(data_home):
-        makedirs(data_home)
+                                Path('~', 'asr_data'))
+    data_home = Path(data_home).expanduser()
+
+    if not data_home.exists():
+        data_home.mkdir(parents=True, exist_ok=True)
+
     return data_home
 
 


### PR DESCRIPTION
Function to automate the process of downloading (and storing) embedding files. 


```python
from asr.models.embedding import download_embedding

download_embedding()
```

Use the argument `data_home` to change the default folder. 

One can set the environment variable to change the default folder.

```
import os

from asr.models.embedding import download_embedding

# set the environment variable
os.environ['ASR_DATA'] = "~/my_asr_embedding_files"

# download the files
download_embedding()

```