### PR TITLE
Fix Travis CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ notifications:
   email: false
 
 install:
+    - pip install tensorflow==1.13.2
     - pip install .
 
 script:


### PR DESCRIPTION
Testing fails on travis using the latest 1.14 tensorflow package. Probably due to memory limitations. Locally the testing works.