### PR TITLE
Implement more intuitive way to stop the training

### DIFF
--- a/asreview/review/oracle.py
+++ b/asreview/review/oracle.py
@@ -50,16 +50,23 @@ class ReviewOracle(BaseReview):
 
         def _interact():
             # interact with the user
-            included = input("Include [1] or exclude [0]: ")
+            included = input("Include [1] or exclude [0] (stop [S]): ")
 
             try:
-                included = int(included)
-
-                if included not in [0, 1]:
+                if included not in ["0", "1", "S", "s"]:
                     raise ValueError
 
-                return included
-            except Exception:
+                # stop by raising KeyBoardError
+                if included in ["s", "S", "STOP"]:
+                    stop_input = input("Are you sure you want to stop [y/n]: ")
+                    if stop_input in ["Y", "y", "yes"]:
+                        raise KeyboardInterrupt
+                    else:
+                        return _interact()
+
+                return int(included)
+
+            except ValueError:
 
                 # try again
                 print(f"Incorrect value '{included}'")


### PR DESCRIPTION
```
Post-traumatic stress disorder in DSM-5: Estimates of prevalence and criteria comparison versus DSM-IV-TR in a non-clinical sample of earthquake survivors
Carmassi, C., Akiskal, H. S., Yong, S. S., Stratta, P., Calderani, E., Massimetti, E., Akiskal, K. K., Rossi, A., "DellOsso, L."

Background The latest edition of DSM (DSM-5) introduced important revisions to PTSD symptomatological criteria, such as a four-factor model and the inclusion of new symptoms. To date, only a few studies have investigated the impact that the proposed DSM-5 criteria will have on prevalence rates of PTSD. Methods An overall sample of 512 adolescents who survived the L'Aquila 2009 earthquake and were previously investigated for the presence of full and partial PTSD, using DSM-IV-TR criteria, were reassessed according to DSM-5 criteria. All subjects completed the Trauma and Loss Spectrum-Self Report (TALS-SR). Results A DSM-5 PTSD diagnosis emerged in 39.8% of subjects, with a significant difference between the two sexes (p<0.001), and an overall 87.1% consistency with DSM-IV-TR. Most of the inconsistent diagnoses that fulfilled DSM-IV-TR criteria but not DSM-5 criteria can be attributed to the subjects not fulfilling the new criterion C (active avoidance). Each DSM-5 symptom was more highly correlated with its corresponding symptom cluster than with other symptom clusters, but two of the new symptoms showed moderate to weak item-cluster correlations. Among DSM-5 PTSD cases: 7 (3.4%) endorsed symptom D3; 151 (74%) D4; 28 (13.7%) both D3 and D4; 75 (36.8%) E2. Limitations The use of a self-report instrument; no information on comorbidity; homogeneity of study sample; lack of assessment on functional impairment; the rates of DSM-IV-TR qualified PTSD in the sample was only 37.5%. Conclusions This study provides an inside look at the empirical performance of the DSM-5 PTSD criteria in a population exposed to a natural disaster, which suggests the need for replication in larger epidemiological samples.

Include [1] or exclude [0] (stop [S]): S
Are you sure you want to stop [y/n]: n

```

Feature Request @Rensvandeschoot 