### PR TITLE
Hyperopt integration

### DIFF
--- a/asreview/__main__.py
+++ b/asreview/__main__.py
@@ -184,6 +184,13 @@ def _parse_arguments(mode, prog=sys.argv[0]):
                  "Only used when --prior_excluded is not given. "
                  f"Default {DEFAULT_N_PRIOR_EXCLUDED}")
 
+        parser.add_argument(
+            "--save_freq",
+            default=1,
+            type=int,
+            help="Save log file approximately every x papers."
+                 "Default 1.")
+
     # logging and verbosity
     parser.add_argument(
         "--log_file", "-l",

--- a/asreview/ascii.py
+++ b/asreview/ascii.py
@@ -46,15 +46,15 @@ ASCII_MSG_ORACLE = """
 
 ASCII_MSG_SIMULATE = """
 ---------------------------------------------------------------------------------
-|                                                                               |
-|  Welcome to the ASReview Automated Systematic Review software.                |
-|  In this mode the computer will simulate how well the ASReview software       |
-|  could have accelerate the systematic review of your dataset.                 |
-|  You can sit back and relax while the computer runs this simulation.          |
-|                                                                               |
+|                                                                                |
+|  Welcome to the ASReview Automated Systematic Review software.                 |
+|  In this mode the computer will simulate how well the ASReview software        |
+|  could have accelerate the systematic review of your dataset.                  |
+|  You can sit back and relax while the computer runs this simulation.           |
+|                                                                                |
 |  GitHub page:        {0: <58}|
 |  Questions/remarks:  {1: <58}|
-|                                                                               |
+|                                                                                |
 ---------------------------------------------------------------------------------
 """.format(GITHUB_PAGE, EMAIL_ADDRESS)
 

--- a/asreview/balance_strategies/__init__.py
+++ b/asreview/balance_strategies/__init__.py
@@ -5,3 +5,4 @@ from asreview.balance_strategies.triple_balance import TripleBalanceTD
 from asreview.balance_strategies.undersampling import undersample
 from asreview.balance_strategies.undersampling import UndersampleTD
 from asreview.balance_strategies.utils import get_balance_strategy
+from asreview.balance_strategies.utils import get_balance_class

--- a/asreview/balance_strategies/base.py
+++ b/asreview/balance_strategies/base.py
@@ -18,3 +18,6 @@ class BaseTrainData(ABC):
 
     def default_kwargs(self):
         return {}
+
+    def hyperopt_space(self):
+        return {}

--- a/asreview/balance_strategies/base.py
+++ b/asreview/balance_strategies/base.py
@@ -7,14 +7,14 @@ from asreview.utils import _unsafe_dict_update
 class BaseTrainData(ABC):
     " Abstract class for balance strategies. "
     def __init__(self, balance_kwargs):
+        self.function = None
         self.balance_kwargs = self.default_kwargs()
         self.balance_kwargs = _unsafe_dict_update(self.balance_kwargs,
                                                   balance_kwargs)
 
-    @abstractmethod
     def func_kwargs(self):
         " Should give back the function and arguments for balancing. "
-        pass
+        return self.function, self.balance_kwargs
 
     def default_kwargs(self):
         return {}

--- a/asreview/balance_strategies/base.py
+++ b/asreview/balance_strategies/base.py
@@ -1,5 +1,4 @@
 from abc import ABC
-from abc import abstractmethod
 
 from asreview.utils import _unsafe_dict_update
 

--- a/asreview/balance_strategies/full_sampling.py
+++ b/asreview/balance_strategies/full_sampling.py
@@ -25,8 +25,6 @@ def full_sample(X, y, train_idx):
 
 
 class FullSampleTD(BaseTrainData):
-    def __init__(self, balance_kwargs):
+    def __init__(self, balance_kwargs, **kwargs):
         super(FullSampleTD, self).__init__(balance_kwargs)
-
-    def func_kwargs(self):
-        return full_sample, self.balance_kwargs
+        self.function = full_sample

--- a/asreview/balance_strategies/full_sampling.py
+++ b/asreview/balance_strategies/full_sampling.py
@@ -25,6 +25,6 @@ def full_sample(X, y, train_idx):
 
 
 class FullSampleTD(BaseTrainData):
-    def __init__(self, balance_kwargs, **kwargs):
+    def __init__(self, balance_kwargs={}, **kwargs):
         super(FullSampleTD, self).__init__(balance_kwargs)
         self.function = full_sample

--- a/asreview/balance_strategies/triple_balance.py
+++ b/asreview/balance_strategies/triple_balance.py
@@ -3,6 +3,7 @@ from math import floor
 from math import log
 
 import numpy as np
+
 from asreview.balance_strategies.base import BaseTrainData
 from asreview.balance_strategies.full_sampling import full_sample
 

--- a/asreview/balance_strategies/triple_balance.py
+++ b/asreview/balance_strategies/triple_balance.py
@@ -132,7 +132,7 @@ def fill_training(src_idx, n_train):
     return dest_idx
 
 
-def triple_balance(X, y, train_idx, query_kwargs={},
+def triple_balance(X, y, train_idx, query_kwargs={"query_src": {}},
                    shuffle=True, **dist_kwargs):
     """
     A more advanced function that does resample the training set.

--- a/asreview/balance_strategies/triple_balance.py
+++ b/asreview/balance_strategies/triple_balance.py
@@ -1,6 +1,5 @@
 import logging
-from math import ceil, floor
-from math import exp
+from math import floor
 from math import log
 
 import numpy as np
@@ -37,9 +36,9 @@ class TripleBalanceTD(BaseTrainData):
             "bal_one_a": hp.lognormal("bal_one_a", 2, 2),
             "bal_one_alpha": hp.uniform("bal_one_alpha", -2, 2),
             "bal_zero_b": hp.uniform("bal_zero_b", 0, 1),
-#             "bal_zero_beta": hp.uniform("bal_zero_beta", 0, 2),
+            # "bal_zero_beta": hp.uniform("bal_zero_beta", 0, 2),
             "bal_zero_max_c": hp.uniform("bal_zero_max_c", 0, 1),
-#             "bal_zero_max_gamma": hp.uniform("bal_zero_max_gamma", 0.01, 2)
+            # "bal_zero_max_gamma": hp.uniform("bal_zero_max_gamma", 0.01, 2)
         }
         return parameter_space
 

--- a/asreview/balance_strategies/triple_balance.py
+++ b/asreview/balance_strategies/triple_balance.py
@@ -1,5 +1,5 @@
 import logging
-from math import ceil
+from math import ceil, floor
 from math import exp
 from math import log
 
@@ -15,34 +15,36 @@ class TripleBalanceTD(BaseTrainData):
     and 0's from max sampling. Thus it only makes sense to use this class in
     combination with the rand_max query strategy.
     """
-    def __init__(self, balance_kwargs={}, fit_kwargs={}, query_kwargs={}):
+    def __init__(self, balance_kwargs={}, query_kwargs={}, **kwargs):
         super(TripleBalanceTD, self).__init__(balance_kwargs)
-        self.balance_kwargs['pref_epochs'] = int(fit_kwargs.get('epochs', 1))
-        self.balance_kwargs['fit_kwargs'] = fit_kwargs
         self.balance_kwargs['query_kwargs'] = query_kwargs
         self.function = triple_balance
 
     def default_kwargs(self):
         defaults = {}
-        defaults['rand_max_b'] = 10.0
-        defaults['rand_max_alpha'] = 1.0
-        defaults['one_zero_beta'] = 0.6
-        defaults['one_zero_delta'] = 0.15
+        defaults['one_a'] = 10.0
+        defaults['one_alpha'] = 1.0
+        defaults['zero_b'] = 0.5
+        defaults['zero_beta'] = 1.0
+        defaults['zero_max_c'] = 0.5
+        defaults['zero_max_gamma'] = 2.0
         defaults['shuffle'] = True
         return defaults
 
     def hyperopt_space(self):
         from hyperopt import hp
         parameter_space = {
-            "bal_rand_max_b": hp.lognormal("bal_rand_max_b", 2, 2),
-            "bal_rand_max_alpha": hp.uniform("bal_rand_max_alpha", 0, 2),
-            "bal_one_zero_delta": hp.uniform("bal_one_zero_delta", 0.001, 0.999),  #noqa
-            "bal_one_zero_beta": hp.uniform("bal_one_zero_beta", 0, 2),
+            "bal_one_a": hp.lognormal("bal_one_a", 2, 2),
+            "bal_one_alpha": hp.uniform("bal_one_alpha", -2, 2),
+            "bal_zero_b": hp.uniform("bal_zero_b", 0, 1),
+#             "bal_zero_beta": hp.uniform("bal_zero_beta", 0, 2),
+            "bal_zero_max_c": hp.uniform("bal_zero_max_c", 0, 1),
+#             "bal_zero_max_gamma": hp.uniform("bal_zero_max_gamma", 0.01, 2)
         }
         return parameter_space
 
 
-def _rand_max_weight(n_one, n_zero_rand, n_zero_max, n_samples, b, alpha):
+def _one_weight(n_one, n_zero, a, alpha):
     """
     Get the weight ratio between random and max samples.
 
@@ -58,12 +60,16 @@ def _rand_max_weight(n_one, n_zero_rand, n_zero_max, n_samples, b, alpha):
     float:
         Weight ratio between random/max instances.
     """
-    frac = (n_one+n_zero_max)/(n_samples-n_zero_rand)
-    ratio = b * exp(-log(b) * frac**alpha)
-    return ratio
+    weight = a * (n_one/n_zero)**(-alpha)
+    return weight
 
 
-def _one_zero_ratio(n_one, n_zero, beta, delta):
+def _zero_weight(n_read, b, beta):
+    weight = 1 - (1-b) * (1+log(n_read))**(-beta)
+    return weight
+
+
+def _zero_max_weight(fraction_read, c, gamma):
     """
     Get the weight ratio between ones and zeros.
 
@@ -79,43 +85,55 @@ def _one_zero_ratio(n_one, n_zero, beta, delta):
     float:
         Weight ratio between 1's and 0's
     """
-    ratio = (1-delta)*(n_one/n_zero)**beta + delta
-    return ratio
+    weight = 1 - (1-c)*(1-fraction_read)**gamma
+    return weight
 
 
-def _get_triple_dist(n_one, n_zero_rand, n_zero_max, n_samples, rand_max_b=10,
-                     rand_max_alpha=1.0, one_zero_beta=0.6,
-                     one_zero_delta=0.15):
+def random_round(value):
+    base = int(floor(value))
+    if np.random.rand() < value-base:
+        base += 1
+    return base
+
+
+def _get_triple_dist(n_one, n_zero_rand, n_zero_max, n_samples, n_train,
+                     one_a, one_alpha,
+                     zero_b, zero_beta,
+                     zero_max_c, zero_max_gamma):
     " Get the number of 1's, random 0's and max 0's in each mini epoch. "
-    n_zero = n_zero_rand+n_zero_max
+    n_zero = n_zero_rand + n_zero_max
+    n_read = n_one + n_zero
+    one_weight = _one_weight(n_one, n_zero, one_a, one_alpha)
+    zero_weight = _zero_weight(n_read, zero_b, zero_beta)
+    zero_max_weight = _zero_max_weight(
+        n_read/n_samples, zero_max_c, zero_max_gamma)
 
-    # First get the number of ones and zeros in each mini epoch.
-    oz_ratio = _one_zero_ratio(n_one, n_zero, one_zero_beta, one_zero_delta)
-    n_zero_epoch = ceil(n_one/oz_ratio)
+    tot_zo_weight = one_weight * n_one + zero_weight * n_zero
 
-    # Then the number of random zeros and max zeros in each mini epoch.
-    rand_max_wr = _rand_max_weight(n_one, n_zero_rand, n_zero_max, n_samples,
-                                   rand_max_b, rand_max_alpha)
-    if n_zero_max:
-        n_zero_rand_epoch = n_zero_epoch/(rand_max_wr+n_zero_max/n_zero_rand)
-        n_zero_rand_epoch = ceil(rand_max_wr*n_zero_rand_epoch)
-    else:
-        n_zero_rand_epoch = n_zero_epoch
-    n_zero_max_epoch = n_zero_epoch-n_zero_rand_epoch
+    n_one_train = random_round(one_weight*n_one*n_train/tot_zo_weight)
+    n_one_train = min(n_train-2, n_one_train)
+    n_zero_train = n_train-n_one_train
 
-    return n_one, n_zero_rand_epoch, n_zero_max_epoch
+    tot_rm_weight = 1*n_zero_rand + zero_max_weight*n_zero_max
+    n_zero_rand_train = random_round(
+        n_zero_train * 1*n_zero_rand/tot_rm_weight)
+    n_zero_rand_train = min(n_zero_rand-1, n_zero_rand_train)
+    n_zero_max_train = n_zero_train - n_zero_rand_train
 
-
-def _n_mini_epoch(n_samples, epoch_size):
-    " Compute the size of mini epochs needed to use all data. "
-    if n_samples <= 0 or epoch_size <= 0:
-        return 0
-    return ceil(n_samples/epoch_size)
+    return n_one_train, n_zero_rand_train, n_zero_max_train
 
 
-def triple_balance(X, y, train_idx, fit_kwargs={},
-                   query_kwargs={"query_src": {}},
-                   pref_epochs=1, shuffle=True, **dist_kwargs):
+def fill_training(src_idx, n_train):
+    n_copy = np.int(n_train/len(src_idx))
+    n_sample = n_train - n_copy*len(src_idx)
+    dest_idx = np.tile(src_idx, n_copy).reshape(-1)
+    dest_idx = np.append(dest_idx,
+                         np.random.choice(src_idx, n_sample, replace=False))
+    return dest_idx
+
+
+def triple_balance(X, y, train_idx, query_kwargs={},
+                   shuffle=True, **dist_kwargs):
     """
     A more advanced function that does resample the training set.
     Most likely only useful in combination with NN's, and possibly other
@@ -156,54 +174,21 @@ def triple_balance(X, y, train_idx, fit_kwargs={},
     n_zero_rand = len(zero_rand_idx)
     n_zero_max = len(zero_max_idx)
     n_samples = len(y)
+    n_train = len(train_idx)
 
     # Get the distribution of 1's, and random 0's and max 0's.
-    n_one_epoch, n_zero_rand_epoch, n_zero_max_epoch = _get_triple_dist(
-        n_one, n_zero_rand, n_zero_max, n_samples, **dist_kwargs)
+    n_one_train, n_zero_rand_train, n_zero_max_train = _get_triple_dist(
+        n_one, n_zero_rand, n_zero_max, n_samples, n_train, **dist_kwargs)
     logging.debug(f"(1, 0_rand, 0_max) = "
-                  f"({n_one_epoch}, {n_zero_rand_epoch}, {n_zero_max_epoch})")
+                  f"({n_one_train}, {n_zero_rand_train}, {n_zero_max_train})")
 
-    # Calculate the number of mini epochs, and # of samples for each group.
-    n_mini_epoch = max(_n_mini_epoch(n_one, n_one_epoch),
-                       _n_mini_epoch(n_zero_rand, n_zero_rand_epoch),
-                       _n_mini_epoch(n_zero_max, n_zero_max_epoch)
-                       )
+    one_train_idx = fill_training(one_idx, n_one_train)
+    zero_rand_train_idx = fill_training(zero_rand_idx, n_zero_rand_train)
+    zero_max_train_idx = fill_training(zero_max_idx, n_zero_max_train)
 
-    # Replicate the indices until we have enough.
-    while len(one_idx) < n_one_epoch*n_mini_epoch:
-        one_idx = np.append(one_idx, one_idx)
-    while (n_zero_rand_epoch and
-           len(zero_rand_idx) < n_zero_rand_epoch*n_mini_epoch):
-        zero_rand_idx = np.append(zero_rand_idx, zero_rand_idx)
-    while (n_zero_max_epoch and
-           len(zero_max_idx) < n_zero_max_epoch*n_mini_epoch):
-        zero_max_idx = np.append(zero_max_idx, zero_max_idx)
+#     print(one_train_idx, zero_rand_train_idx, zero_max_train_idx)
+    all_idx = np.concatenate(
+        [one_train_idx, zero_rand_train_idx, zero_max_train_idx])
+    np.random.shuffle(all_idx)
 
-    # Build the training set from the three groups.
-    all_idx = np.array([], dtype=int)
-    for i in range(n_mini_epoch):
-        new_one_idx = one_idx[i*n_one_epoch:(i+1)*n_one_epoch]
-        new_zero_rand_idx = zero_rand_idx[
-            i*n_zero_rand_epoch:(i+1)*n_zero_rand_epoch]
-        new_zero_max_idx = zero_max_idx[
-            i*n_zero_max_epoch:(i+1)*n_zero_max_epoch]
-        new_idx = new_one_idx
-        new_idx = np.append(new_idx, new_zero_rand_idx)
-        new_idx = np.append(new_idx, new_zero_max_idx)
-        if shuffle:
-            np.random.shuffle(new_idx)
-        all_idx = np.append(all_idx, new_idx)
-
-    # Set the number of epochs in the fit_kwargs.
-    if 'epochs' in fit_kwargs:
-        efrac_one = n_one_epoch/n_one
-        efrac_zero_rand = n_zero_rand_epoch/n_zero_rand
-        if n_zero_max:
-            efrac_zero_max = n_zero_max_epoch/n_zero_max
-            efrac = (efrac_one*efrac_zero_rand*efrac_zero_max)**(1./3.)
-        else:
-            efrac = (efrac_one*efrac_zero_rand)**(1./2.)
-        efrac = 1.0
-        logging.debug(f"Fraction of mini epoch = {efrac}")
-        fit_kwargs['epochs'] = ceil(pref_epochs/(efrac*n_mini_epoch))
     return X[all_idx], y[all_idx]

--- a/asreview/balance_strategies/triple_balance.py
+++ b/asreview/balance_strategies/triple_balance.py
@@ -15,14 +15,12 @@ class TripleBalanceTD(BaseTrainData):
     and 0's from max sampling. Thus it only makes sense to use this class in
     combination with the rand_max query strategy.
     """
-    def __init__(self, balance_kwargs, fit_kwargs, query_kwargs):
+    def __init__(self, balance_kwargs={}, fit_kwargs={}, query_kwargs={}):
         super(TripleBalanceTD, self).__init__(balance_kwargs)
         self.balance_kwargs['pref_epochs'] = int(fit_kwargs.get('epochs', 1))
         self.balance_kwargs['fit_kwargs'] = fit_kwargs
         self.balance_kwargs['query_kwargs'] = query_kwargs
-
-    def func_kwargs(self):
-        return triple_balance, self.balance_kwargs
+        self.function = triple_balance
 
     def default_kwargs(self):
         defaults = {}
@@ -38,7 +36,7 @@ class TripleBalanceTD(BaseTrainData):
         parameter_space = {
             "bal_rand_max_b": hp.lognormal("bal_rand_max_b", 2, 2),
             "bal_rand_max_alpha": hp.uniform("bal_rand_max_alpha", 0, 2),
-            "bal_one_zero_delta": hp.uniform("bal_one_zero_delta", 0.999, 0.001),
+            "bal_one_zero_delta": hp.uniform("bal_one_zero_delta", 0.001, 0.999),  #noqa
             "bal_one_zero_beta": hp.uniform("bal_one_zero_beta", 0, 2),
         }
         return parameter_space

--- a/asreview/balance_strategies/triple_balance.py
+++ b/asreview/balance_strategies/triple_balance.py
@@ -111,13 +111,13 @@ def _get_triple_dist(n_one, n_zero_rand, n_zero_max, n_samples, n_train,
     tot_zo_weight = one_weight * n_one + zero_weight * n_zero
 
     n_one_train = random_round(one_weight*n_one*n_train/tot_zo_weight)
-    n_one_train = min(n_train-2, n_one_train)
+    n_one_train = max(1, min(n_train-2, n_one_train))
     n_zero_train = n_train-n_one_train
 
     tot_rm_weight = 1*n_zero_rand + zero_max_weight*n_zero_max
     n_zero_rand_train = random_round(
         n_zero_train * 1*n_zero_rand/tot_rm_weight)
-    n_zero_rand_train = min(n_zero_rand-1, n_zero_rand_train)
+    n_zero_rand_train = max(1, min(n_zero_rand-1, n_zero_rand_train))
     n_zero_max_train = n_zero_train - n_zero_rand_train
 
     return n_one_train, n_zero_rand_train, n_zero_max_train

--- a/asreview/balance_strategies/triple_balance.py
+++ b/asreview/balance_strategies/triple_balance.py
@@ -24,7 +24,7 @@ class TripleBalanceTD(BaseTrainData):
 
     def default_kwargs(self):
         defaults = {}
-        defaults['rand_max_b'] = 10
+        defaults['rand_max_b'] = 10.0
         defaults['rand_max_alpha'] = 1.0
         defaults['one_zero_beta'] = 0.6
         defaults['one_zero_delta'] = 0.15

--- a/asreview/balance_strategies/triple_balance.py
+++ b/asreview/balance_strategies/triple_balance.py
@@ -33,6 +33,16 @@ class TripleBalanceTD(BaseTrainData):
         defaults['shuffle'] = True
         return defaults
 
+    def hyperopt_space(self):
+        from hyperopt import hp
+        parameter_space = {
+            "bal_rand_max_b": hp.lognormal("bal_rand_max_b", 2, 2),
+            "bal_rand_max_alpha": hp.uniform("bal_rand_max_alpha", 0, 2),
+            "bal_one_zero_delta": hp.uniform("bal_one_zero_delta", 0.999, 0.001),
+            "bal_one_zero_beta": hp.uniform("bal_one_zero_beta", 0, 2),
+        }
+        return parameter_space
+
 
 def _rand_max_weight(n_one, n_zero_rand, n_zero_max, n_samples, b, alpha):
     """

--- a/asreview/balance_strategies/undersampling.py
+++ b/asreview/balance_strategies/undersampling.py
@@ -1,6 +1,7 @@
 from math import ceil
 
 import numpy as np
+
 from asreview.balance_strategies.base import BaseTrainData
 
 

--- a/asreview/balance_strategies/undersampling.py
+++ b/asreview/balance_strategies/undersampling.py
@@ -8,23 +8,27 @@ class UndersampleTD(BaseTrainData):
     """
     Balancing class that undersamples the data with a given ratio.
     """
-    def __init__(self, balance_kwargs, fit_kwargs):
+    def __init__(self, balance_kwargs={}):
         super(UndersampleTD, self).__init__(balance_kwargs)
-        if 'shuffle' in fit_kwargs:
-            self.balance_kwargs['shuffle'] = fit_kwargs['shuffle']
-            fit_kwargs['shuffle'] = False
+        self.function = undersample
 
-    def func_kwargs(self):
-        return undersample, self.balance_kwargs
+#     def func_kwargs(self):
+#         return undersample, self.balance_kwargs
 
     def default_kwargs(self):
         defaults = {}
-        defaults['shuffle'] = True
         defaults['ratio'] = 1.0
         return defaults
 
+    def hyperopt_space(self):
+        from hyperopt import hp
+        parameter_space = {
+            "bal_ratio": hp.lognormal('bal_ratio', 0, 1),
+        }
+        return parameter_space
 
-def undersample(X, y, train_idx, ratio=1.0, shuffle=True):
+
+def undersample(X, y, train_idx, ratio=1.0):
     """ Undersample the training set to balance 1's and 0's. """
 
     one_ind = train_idx[np.where(y[train_idx] == 1)]
@@ -42,6 +46,5 @@ def undersample(X, y, train_idx, ratio=1.0, shuffle=True):
                                       replace=False)
         shuf_ind = np.append(one_ind, zero_ind[zero_under])
 
-    if shuffle:
-        np.random.shuffle(shuf_ind)
+    np.random.shuffle(shuf_ind)
     return X[shuf_ind], y[shuf_ind]

--- a/asreview/balance_strategies/undersampling.py
+++ b/asreview/balance_strategies/undersampling.py
@@ -8,12 +8,9 @@ class UndersampleTD(BaseTrainData):
     """
     Balancing class that undersamples the data with a given ratio.
     """
-    def __init__(self, balance_kwargs={}):
+    def __init__(self, balance_kwargs={}, **kwargs):
         super(UndersampleTD, self).__init__(balance_kwargs)
         self.function = undersample
-
-#     def func_kwargs(self):
-#         return undersample, self.balance_kwargs
 
     def default_kwargs(self):
         defaults = {}

--- a/asreview/balance_strategies/utils.py
+++ b/asreview/balance_strategies/utils.py
@@ -13,7 +13,7 @@ def get_balance_strategy(settings):
         td_string = "all training data"
     elif method == "triple_balance":
         td_obj = TripleBalanceTD(
-            settings.balance_param, settings.fit_kwargs, settings.query_kwargs)
+            settings.balance_param, settings.query_kwargs)
         td_string = "triple balanced (max,rand) training data"
     elif method in ["undersample", "undersampling"]:
         td_obj = UndersampleTD(settings.balance_param)

--- a/asreview/balance_strategies/utils.py
+++ b/asreview/balance_strategies/utils.py
@@ -22,3 +22,12 @@ def get_balance_strategy(settings):
         raise ValueError(f"Training data method {method} not found")
     func, settings.balance_kwargs = td_obj.func_kwargs()
     return func, td_string
+
+
+def get_balance_class(method):
+    if method in ["simple", "full"]:
+        return FullSampleTD
+    if method in ["triple", "triple_balance"]:
+        return TripleBalanceTD
+    if method in ["undersample", "undersampling"]:
+        return UndersampleTD

--- a/asreview/balance_strategies/utils.py
+++ b/asreview/balance_strategies/utils.py
@@ -16,7 +16,7 @@ def get_balance_strategy(settings):
             settings.balance_param, settings.fit_kwargs, settings.query_kwargs)
         td_string = "triple balanced (max,rand) training data"
     elif method in ["undersample", "undersampling"]:
-        td_obj = UndersampleTD(settings.balance_param, settings.fit_kwargs)
+        td_obj = UndersampleTD(settings.balance_param)
         td_string = "undersampled training data"
     else:
         raise ValueError(f"Training data method {method} not found")

--- a/asreview/logging.py
+++ b/asreview/logging.py
@@ -4,8 +4,9 @@ from collections import OrderedDict
 from datetime import datetime
 from pathlib import Path
 
-import asreview
 import numpy as np
+
+import asreview
 from asreview.settings import ASReviewSettings
 
 

--- a/asreview/models/__init__.py
+++ b/asreview/models/__init__.py
@@ -1,7 +1,4 @@
 from asreview.models.lstm_base import create_lstm_base_model
-from asreview.models.lstm_base import lstm_base_model_defaults
-from asreview.models.lstm_base import lstm_fit_defaults
 from asreview.models.lstm_pool import create_lstm_pool_model
-from asreview.models.lstm_pool import lstm_pool_model_defaults
 from asreview.models.sklearn_models import create_nb_model
 from asreview.models.sklearn_models import create_svc_model

--- a/asreview/models/__init__.py
+++ b/asreview/models/__init__.py
@@ -1,4 +1,5 @@
-from asreview.models.lstm_base import create_lstm_base_model
-from asreview.models.lstm_pool import create_lstm_pool_model
-from asreview.models.sklearn_models import create_nb_model
-from asreview.models.sklearn_models import create_svc_model
+from asreview.models.lstm_base import create_lstm_base_model, LSTMBaseModel
+from asreview.models.lstm_pool import create_lstm_pool_model, LSTMPoolModel
+from asreview.models.sklearn_models import create_nb_model, NBModel
+from asreview.models.sklearn_models import create_svc_model, SVCModel
+from asreview.models.utils import get_model_class

--- a/asreview/models/base.py
+++ b/asreview/models/base.py
@@ -23,6 +23,9 @@ class BaseModel(ABC):
     def model(self):
         raise NotImplementedError
 
+    def get_Xy(self):
+        raise NotImplementedError
+
     def default_param(self):
         return {}
 

--- a/asreview/models/base.py
+++ b/asreview/models/base.py
@@ -4,24 +4,26 @@ from asreview.utils import _unsafe_dict_update
 
 
 class BaseModel(ABC):
-    def __init__(self, model_param, fit_param):
+    def __init__(self, param):
         self.name = "base"
-        self.model_param = _unsafe_dict_update(
-            self.default_param(), model_param)
-        self.fit_param = _unsafe_dict_update(
-            self.default_fit_param(), fit_param)
+        self.param = _unsafe_dict_update(self.default_param(), param)
+
+    def fit_param(self):
+        fit_param = {x: self.param[x] for x in self.fit_param_names()}
+        return fit_param
+
+    def model_param(self):
+        model_param = {x: self.param[x] for x in self.model_param_names()}
+        return model_param
 
     def fit_kwargs(self):
-        return self.fit_param
+        return self.fit_param()
 
     @abstractmethod
     def model(self):
         raise NotImplementedError
 
     def default_param(self):
-        return {}
-
-    def default_fit_param(self):
         return {}
 
     def full_hyper_space(self):
@@ -47,3 +49,9 @@ class BaseModel(ABC):
 
     def _small(self, par):
         return par[4:]
+
+    def model_param_names(self):
+        return list(self.param.keys())
+
+    def fit_param_names(self):
+        return []

--- a/asreview/models/base.py
+++ b/asreview/models/base.py
@@ -1,0 +1,44 @@
+from abc import ABC, abstractmethod
+
+from asreview.utils import _unsafe_dict_update
+
+
+class BaseModel(ABC):
+    def __init__(self, model_kwargs):
+        self.name = "base"
+        self.model_kwargs = self.default_kwargs()
+        self.model_kwargs = _unsafe_dict_update(self.model_kwargs, model_kwargs)
+
+    def model_kwargs(self):
+        return self.model(), self.model_kwargs
+
+    @abstractmethod
+    def model(self):
+        raise NotImplementedError
+
+    def default_kwargs(self):
+        return {}
+
+    def full_hyper_space(self):
+        return {}, {}
+
+    def hyper_space(self, exclude=[], **kwargs):
+        from hyperopt import hp
+        hyper_space, hyper_choices = self.full_hyper_space()
+
+        for hyper_par in exclude:
+            hyper_space.pop(self._full(hyper_par), None)
+            hyper_choices.pop(self._full(hyper_par), None)
+
+        for hyper_par in kwargs:
+            full_hyper = self._full(hyper_par)
+            hyper_val = kwargs[hyper_par]
+            hyper_space[full_hyper] = hp.choice(full_hyper, [hyper_val])
+            hyper_choices[full_hyper] = [hyper_val]
+        return hyper_space, hyper_choices
+
+    def _full(self, par):
+        return "mdl_" + par
+
+    def _small(self, par):
+        return par[4:]

--- a/asreview/models/base.py
+++ b/asreview/models/base.py
@@ -4,19 +4,24 @@ from asreview.utils import _unsafe_dict_update
 
 
 class BaseModel(ABC):
-    def __init__(self, model_kwargs):
+    def __init__(self, model_param, fit_param):
         self.name = "base"
-        self.model_kwargs = self.default_kwargs()
-        self.model_kwargs = _unsafe_dict_update(self.model_kwargs, model_kwargs)
+        self.model_param = _unsafe_dict_update(
+            self.default_param(), model_param)
+        self.fit_param = _unsafe_dict_update(
+            self.default_fit_param(), fit_param)
 
-    def model_kwargs(self):
-        return self.model(), self.model_kwargs
+    def fit_kwargs(self):
+        return self.fit_param
 
     @abstractmethod
     def model(self):
         raise NotImplementedError
 
-    def default_kwargs(self):
+    def default_param(self):
+        return {}
+
+    def default_fit_param(self):
         return {}
 
     def full_hyper_space(self):

--- a/asreview/models/embedding.py
+++ b/asreview/models/embedding.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from urllib.request import urlopen
 
 import numpy as np
+
 from asreview.utils import get_data_home
 
 

--- a/asreview/models/keras.py
+++ b/asreview/models/keras.py
@@ -2,19 +2,16 @@ import logging
 import time
 from pathlib import Path
 
+from tensorflow.keras import optimizers
+
 from asreview.models.base import BaseModel
-
-from asreview.utils import get_data_home
-from asreview.utils import text_to_features
-
 from asreview.models.embedding import download_embedding
 from asreview.models.embedding import EMBEDDING_EN
 from asreview.models.embedding import load_embedding
 from asreview.models.embedding import sample_embedding
-
+from asreview.utils import get_data_home
+from asreview.utils import text_to_features
 from asreview.utils import _set_class_weight
-
-from tensorflow.keras import optimizers
 
 
 def _get_optimizer(optimizer, lr_mult=1.0):

--- a/asreview/models/keras.py
+++ b/asreview/models/keras.py
@@ -1,0 +1,80 @@
+import logging
+import time
+from pathlib import Path
+
+from asreview.models.base import BaseModel
+
+from asreview.utils import get_data_home
+from asreview.utils import text_to_features
+
+from asreview.models.embedding import download_embedding
+from asreview.models.embedding import EMBEDDING_EN
+from asreview.models.embedding import load_embedding
+from asreview.models.embedding import sample_embedding
+
+from asreview.utils import _set_class_weight
+
+from tensorflow.keras import optimizers
+
+
+def _get_optimizer(optimizer, lr_mult=1.0):
+    if optimizer == "sgd":
+        return optimizers.SGD(learning_rate=0.01*lr_mult)
+    elif optimizer == "rmsprop":
+        return optimizers.RMSprop(learning_rate=0.001*lr_mult)
+    elif optimizer == "adagrad":
+        return optimizers.Adagrad(learning_rate=0.01*lr_mult)
+    elif optimizer == "adam":
+        return optimizers.Adam(learning_rate=0.001*lr_mult)
+    elif optimizer == "nadam":
+        return optimizers.Nadam(learning_rate=0.002*lr_mult)
+    raise NotImplementedError
+
+
+class KerasModel(BaseModel):
+    def __init__(self, param={}, embedding_fp=None, **kwargs):
+        super(KerasModel, self).__init__(param)
+        self.name = "keras"
+
+        self.embedding_fp = embedding_fp
+        self.embedding_matrix = None
+        self.word_index = None
+
+    def get_Xy(self, texts, labels):
+        self.X, self.word_index = text_to_features(texts)
+        self.y = labels
+        return self.X, self.y
+
+    def fit_kwargs(self):
+        fit_kwargs = self.fit_param()
+        class_weight_inc = fit_kwargs.pop('class_weight_inc', None)
+        if class_weight_inc is not None:
+            fit_kwargs['class_weight'] = _set_class_weight(class_weight_inc)
+        return fit_kwargs
+
+    def get_embedding_matrix(self):
+        if self.embedding_matrix is not None:
+            return self.embedding_matrix
+
+        if self.word_index is None:
+            self.get_Xy()
+
+        if self.embedding_fp is None:
+            self.embedding_fp = Path(
+                get_data_home(),
+                EMBEDDING_EN["name"]
+            ).expanduser()
+
+            if not self.embedding_fp.exists():
+                print("Warning: will start to download large "
+                      "embedding file in 10 seconds.")
+                time.sleep(10)
+                download_embedding()
+
+        # create features and labels
+        logging.info("Loading embedding matrix. "
+                     "This can take several minutes.")
+        embedding = load_embedding(self.embedding_fp,
+                                   word_index=self.word_index)
+        self.embedding_matrix = sample_embedding(embedding, self.word_index)
+        return self.embedding_matrix

--- a/asreview/models/keras.py
+++ b/asreview/models/keras.py
@@ -19,15 +19,15 @@ from tensorflow.keras import optimizers
 
 def _get_optimizer(optimizer, lr_mult=1.0):
     if optimizer == "sgd":
-        return optimizers.SGD(learning_rate=0.01*lr_mult)
+        return optimizers.SGD(lr=0.01*lr_mult)
     elif optimizer == "rmsprop":
-        return optimizers.RMSprop(learning_rate=0.001*lr_mult)
+        return optimizers.RMSprop(lr=0.001*lr_mult)
     elif optimizer == "adagrad":
-        return optimizers.Adagrad(learning_rate=0.01*lr_mult)
+        return optimizers.Adagrad(lr=0.01*lr_mult)
     elif optimizer == "adam":
-        return optimizers.Adam(learning_rate=0.001*lr_mult)
+        return optimizers.Adam(lr=0.001*lr_mult)
     elif optimizer == "nadam":
-        return optimizers.Nadam(learning_rate=0.002*lr_mult)
+        return optimizers.Nadam(lr=0.002*lr_mult)
     raise NotImplementedError
 
 

--- a/asreview/models/lstm_base.py
+++ b/asreview/models/lstm_base.py
@@ -1,9 +1,11 @@
-from asreview.utils import _set_class_weight
-from asreview.utils import _unsafe_dict_update
 from tensorflow.keras.layers import Dense
 from tensorflow.keras.layers import Embedding
 from tensorflow.keras.layers import LSTM
 from tensorflow.keras.models import Sequential
+
+from asreview.utils import _set_class_weight
+from asreview.utils import _unsafe_dict_update
+from asreview.models.base import BaseModel
 
 
 def lstm_base_model_defaults(settings, verbose=1):
@@ -117,3 +119,25 @@ def create_lstm_base_model(embedding_matrix,
         return model
 
     return wrap_model
+
+
+class LSTMBaseModel(BaseModel):
+    def __init__(self, model_kwargs={}, **kwargs):
+        super(LSTMBaseModel, self).__init__(model_kwargs)
+        self.name = "lstm_base"
+
+    def model(self, embedding_matrix):
+        model = create_lstm_base_model(embedding_matrix, **self.model_kwargs)
+        return model
+
+    def default_kwargs(self):
+        kwargs = {
+            "backwards": True,
+            "dropout": 0.4,
+            "optimizer": "rmsprop",
+            "max_sequence_length": 1000,
+            "lstm_out_width": 20,
+            "dense_width": 128,
+            "verbose": 1,
+        }
+        return kwargs

--- a/asreview/models/lstm_base.py
+++ b/asreview/models/lstm_base.py
@@ -86,15 +86,16 @@ def create_lstm_base_model(embedding_matrix,
 
 
 class LSTMBaseModel(KerasModel):
-    def __init__(self, model_param={}, fit_param={}, **kwargs):
-        super(LSTMBaseModel, self).__init__(model_param, fit_param, **kwargs)
+    def __init__(self, param, **kwargs):
+        super(LSTMBaseModel, self).__init__(param, **kwargs)
         self.name = "lstm_base"
 
     def model(self):
         embedding_matrix = self.get_embedding_matrix()
-        model = create_lstm_base_model(embedding_matrix, **self.model_param)
-        return KerasClassifier(model,
-                               verbose=self.model_param.get("verbose", 0))
+        model_param = self.model_param()
+        model = create_lstm_base_model(embedding_matrix, **model_param)
+        verbose = model_param.get("verbose", self.default_param()["verbose"])
+        return KerasClassifier(model, verbose=verbose)
 
     def default_param(self):
         kwargs = {
@@ -134,7 +135,7 @@ class LSTMBaseModel(KerasModel):
 
     def model_param_names(self):
         param_names = [
-            "backward", "dropout", "optimizer", "max_sequence_length",
+            "backwards", "dropout", "optimizer", "max_sequence_length",
             "lstm_out_width", "dense_width", "verbose",
         ]
         return param_names

--- a/asreview/models/lstm_base.py
+++ b/asreview/models/lstm_base.py
@@ -1,7 +1,3 @@
-import copy
-import logging
-import time
-from pathlib import Path
 
 from tensorflow.keras.layers import Dense
 from tensorflow.keras.layers import Embedding
@@ -9,54 +5,7 @@ from tensorflow.keras.layers import LSTM
 from tensorflow.keras.models import Sequential
 from tensorflow.keras.wrappers.scikit_learn import KerasClassifier
 
-
-from asreview.utils import _set_class_weight
-from asreview.utils import _unsafe_dict_update
-from asreview.models.base import BaseModel
-
-from asreview.utils import get_data_home
-from asreview.utils import text_to_features
-
-from asreview.models.embedding import download_embedding
-from asreview.models.embedding import EMBEDDING_EN
-from asreview.models.embedding import load_embedding
-from asreview.models.embedding import sample_embedding
-
-
-def lstm_base_model_defaults(settings, verbose=1):
-    """ Set the lstm model defaults. """
-    model_kwargs = {}
-    model_kwargs['backwards'] = True
-    model_kwargs['dropout'] = 0.4
-    model_kwargs['optimizer'] = "rmsprop"
-    model_kwargs['max_sequence_length'] = 1000
-    model_kwargs['verbose'] = verbose
-    model_kwargs['lstm_out_width'] = 20
-    model_kwargs['dense_width'] = 128
-
-    upd_param = _unsafe_dict_update(model_kwargs, settings.model_param)
-    settings.model_param = upd_param
-
-    return upd_param
-
-
-def lstm_fit_defaults(settings, verbose=1):
-    """ Set the fit defaults and merge them with custom settings. """
-
-    # arguments to pass to the fit
-    fit_kwargs = {}
-    fit_kwargs['batch_size'] = 32
-    fit_kwargs['epochs'] = 10
-    fit_kwargs['verbose'] = verbose
-    fit_kwargs['shuffle'] = False
-    fit_kwargs['class_weight_inc'] = 30.0
-
-    settings.fit_kwargs = _unsafe_dict_update(
-        fit_kwargs, settings.fit_param)
-
-    _set_class_weight(fit_kwargs.pop('class_weight_inc'), fit_kwargs)
-
-    return settings.fit_kwargs
+from asreview.models.keras import KerasModel
 
 
 def create_lstm_base_model(embedding_matrix,
@@ -136,54 +85,6 @@ def create_lstm_base_model(embedding_matrix,
     return wrap_model
 
 
-class KerasModel(BaseModel):
-    def __init__(self, model_param={}, fit_param={}, embedding_fp=None, **kwargs):
-        super(KerasModel, self).__init__(model_param, fit_param)
-        self.name = "keras"
-
-        self.embedding_fp = embedding_fp
-        self.embedding_matrix = None
-        self.word_index = None
-
-    def get_Xy(self, texts, labels):
-        self.X, self.word_index = text_to_features(texts)
-        self.y = labels
-        return self.X, self.y
-
-    def fit_kwargs(self):
-        fit_kwargs = copy.deepcopy(self.fit_param)
-        class_weight_inc = fit_kwargs.pop('class_weight_inc')
-        fit_kwargs['class_weight'] = _set_class_weight(class_weight_inc)
-        return fit_kwargs
-
-    def get_embedding_matrix(self):
-        if self.embedding_matrix is not None:
-            return self.embedding_matrix
-
-        if self.word_index is None:
-            self.get_Xy()
-
-        if self.embedding_fp is None:
-            self.embedding_fp = Path(
-                get_data_home(),
-                EMBEDDING_EN["name"]
-            ).expanduser()
-
-            if not self.embedding_fp.exists():
-                print("Warning: will start to download large "
-                      "embedding file in 10 seconds.")
-                time.sleep(10)
-                download_embedding()
-
-        # create features and labels
-        logging.info("Loading embedding matrix. "
-                     "This can take several minutes.")
-        embedding = load_embedding(self.embedding_fp,
-                                   word_index=self.word_index)
-        self.embedding_matrix = sample_embedding(embedding, self.word_index)
-        return self.embedding_matrix
-
-
 class LSTMBaseModel(KerasModel):
     def __init__(self, model_param={}, fit_param={}, **kwargs):
         super(LSTMBaseModel, self).__init__(model_param, fit_param, **kwargs)
@@ -204,18 +105,12 @@ class LSTMBaseModel(KerasModel):
             "lstm_out_width": 20,
             "dense_width": 128,
             "verbose": 1,
+            "batch_size": 32,
+            "epochs": 10,
+            "shuffle": False,
+            "class_weight_inc": 30.0,
         }
         return kwargs
-
-    def default_fit_param(self):
-        fit_param = dict(
-            batch_size=32,
-            epochs=10,
-            verbose=0,
-            shuffle=False,
-            class_weight_inc=30.0
-        )
-        return fit_param
 
     def full_hyper_space(self):
         from hyperopt import hp
@@ -230,3 +125,16 @@ class LSTMBaseModel(KerasModel):
             "mdl_dense_width": hp.quniform("mdl_dense_width", 1, 200, 1),
         }
         return hyper_space, hyper_choices
+
+    def fit_param_names(self):
+        param_names = [
+            "batch_size", "epochs", "shuffle", "class_weight_inc", "verbose",
+        ]
+        return param_names
+
+    def model_param_names(self):
+        param_names = [
+            "backward", "dropout", "optimizer", "max_sequence_length",
+            "lstm_out_width", "dense_width", "verbose",
+        ]
+        return param_names

--- a/asreview/models/lstm_base.py
+++ b/asreview/models/lstm_base.py
@@ -1,11 +1,26 @@
+import copy
+import logging
+import time
+from pathlib import Path
+
 from tensorflow.keras.layers import Dense
 from tensorflow.keras.layers import Embedding
 from tensorflow.keras.layers import LSTM
 from tensorflow.keras.models import Sequential
+from tensorflow.keras.wrappers.scikit_learn import KerasClassifier
+
 
 from asreview.utils import _set_class_weight
 from asreview.utils import _unsafe_dict_update
 from asreview.models.base import BaseModel
+
+from asreview.utils import get_data_home
+from asreview.utils import text_to_features
+
+from asreview.models.embedding import download_embedding
+from asreview.models.embedding import EMBEDDING_EN
+from asreview.models.embedding import load_embedding
+from asreview.models.embedding import sample_embedding
 
 
 def lstm_base_model_defaults(settings, verbose=1):
@@ -121,16 +136,66 @@ def create_lstm_base_model(embedding_matrix,
     return wrap_model
 
 
-class LSTMBaseModel(BaseModel):
-    def __init__(self, model_kwargs={}, **kwargs):
-        super(LSTMBaseModel, self).__init__(model_kwargs)
+class KerasModel(BaseModel):
+    def __init__(self, model_param={}, fit_param={}, embedding_fp=None, **kwargs):
+        super(KerasModel, self).__init__(model_param, fit_param)
+        self.name = "keras"
+
+        self.embedding_fp = embedding_fp
+        self.embedding_matrix = None
+        self.word_index = None
+
+    def get_Xy(self, texts, labels):
+        self.X, self.word_index = text_to_features(texts)
+        self.y = labels
+        return self.X, self.y
+
+    def fit_kwargs(self):
+        fit_kwargs = copy.deepcopy(self.fit_param)
+        class_weight_inc = fit_kwargs.pop('class_weight_inc')
+        fit_kwargs['class_weight'] = _set_class_weight(class_weight_inc)
+        return fit_kwargs
+
+    def get_embedding_matrix(self):
+        if self.embedding_matrix is not None:
+            return self.embedding_matrix
+
+        if self.word_index is None:
+            self.get_Xy()
+
+        if self.embedding_fp is None:
+            self.embedding_fp = Path(
+                get_data_home(),
+                EMBEDDING_EN["name"]
+            ).expanduser()
+
+            if not self.embedding_fp.exists():
+                print("Warning: will start to download large "
+                      "embedding file in 10 seconds.")
+                time.sleep(10)
+                download_embedding()
+
+        # create features and labels
+        logging.info("Loading embedding matrix. "
+                     "This can take several minutes.")
+        embedding = load_embedding(self.embedding_fp,
+                                   word_index=self.word_index)
+        self.embedding_matrix = sample_embedding(embedding, self.word_index)
+        return self.embedding_matrix
+
+
+class LSTMBaseModel(KerasModel):
+    def __init__(self, model_param={}, fit_param={}, **kwargs):
+        super(LSTMBaseModel, self).__init__(model_param, fit_param, **kwargs)
         self.name = "lstm_base"
 
-    def model(self, embedding_matrix):
-        model = create_lstm_base_model(embedding_matrix, **self.model_kwargs)
-        return model
+    def model(self):
+        embedding_matrix = self.get_embedding_matrix()
+        model = create_lstm_base_model(embedding_matrix, **self.model_param)
+        return KerasClassifier(model,
+                               verbose=self.model_param.get("verbose", 0))
 
-    def default_kwargs(self):
+    def default_param(self):
         kwargs = {
             "backwards": True,
             "dropout": 0.4,
@@ -141,3 +206,27 @@ class LSTMBaseModel(BaseModel):
             "verbose": 1,
         }
         return kwargs
+
+    def default_fit_param(self):
+        fit_param = dict(
+            batch_size=32,
+            epochs=10,
+            verbose=0,
+            shuffle=False,
+            class_weight_inc=30.0
+        )
+        return fit_param
+
+    def full_hyper_space(self):
+        from hyperopt import hp
+        hyper_choices = {
+            "mdl_optimizer": ["sgd", "rmsprop", "adagrad", "adam", "nadam"]
+        }
+        hyper_space = {
+            "mdl_optimizer": hp.choice("mdl_optimizer",
+                                       hyper_choices["mdl_optimizer"]),
+            "mdl_dropout": hp.uniform("mdl_dropout", 0, 0.9),
+            "mdl_lstm_out_width": hp.quniform("mdl_lstm_out_width", 1, 50, 1),
+            "mdl_dense_width": hp.quniform("mdl_dense_width", 1, 200, 1),
+        }
+        return hyper_space, hyper_choices

--- a/asreview/models/lstm_pool.py
+++ b/asreview/models/lstm_pool.py
@@ -95,16 +95,17 @@ def create_lstm_pool_model(embedding_matrix,
     return wrap_model
 
 
-class LSTMBaseModel(KerasModel):
+class LSTMPoolModel(KerasModel):
     def __init__(self, param={}, **kwargs):
-        super(LSTMBaseModel, self).__init__(param, **kwargs)
+        super(LSTMPoolModel, self).__init__(param, **kwargs)
         self.name = "lstm_base"
 
     def model(self):
         embedding_matrix = self.get_embedding_matrix()
-        model = create_lstm_pool_model(embedding_matrix, **self.model_param)
-        return KerasClassifier(model,
-                               verbose=self.model_param.get("verbose", 0))
+        model_param = self.model_param()
+        model = create_lstm_pool_model(embedding_matrix, **model_param)
+        verbose = model_param.get("verbose", self.default_param()["verbose"])
+        return KerasClassifier(model, verbose=verbose)
 
     def default_param(self):
         kwargs = {
@@ -146,7 +147,7 @@ class LSTMBaseModel(KerasModel):
 
     def model_param_names(self):
         param_names = [
-            "backward", "dropout", "optimizer", "max_sequence_length",
+            "backwards", "dropout", "optimizer", "max_sequence_length",
             "lstm_out_width", "lstm_pool_size", "learn_rate_mult", "verbose",
         ]
         return param_names

--- a/asreview/models/lstm_pool.py
+++ b/asreview/models/lstm_pool.py
@@ -1,4 +1,4 @@
-from asreview.utils import _unsafe_dict_update
+
 from tensorflow.keras.constraints import MaxNorm
 from tensorflow.keras.layers import Dense
 from tensorflow.keras.layers import Embedding
@@ -6,26 +6,9 @@ from tensorflow.keras.layers import Flatten
 from tensorflow.keras.layers import LSTM
 from tensorflow.keras.layers import MaxPooling1D
 from tensorflow.keras.models import Sequential
-from tensorflow.keras.optimizers import Adam
-from tensorflow.keras.optimizers import RMSprop
+from tensorflow.keras.wrappers.scikit_learn import KerasClassifier
 
-
-def lstm_pool_model_defaults(settings, verbose=1):
-    """ Set the lstm model defaults. """
-    model_kwargs = {}
-    model_kwargs['backwards'] = True
-    model_kwargs['dropout'] = 0.4
-    model_kwargs['optimizer'] = "rmsprop"
-    model_kwargs['max_sequence_length'] = 1000
-    model_kwargs['verbose'] = verbose
-    model_kwargs['lstm_out_width'] = 20
-    model_kwargs['lstm_pool_size'] = 100
-    model_kwargs['learn_rate_mult'] = 1.0
-
-    upd_param = _unsafe_dict_update(model_kwargs, settings.model_param)
-    settings.model_param = upd_param
-
-    return upd_param
+from asreview.models.keras import KerasModel, _get_optimizer
 
 
 def create_lstm_pool_model(embedding_matrix,
@@ -97,10 +80,7 @@ def create_lstm_pool_model(embedding_matrix,
             )
         )
 
-        if optimizer == "rmsprop":
-            optimizer_fn = RMSprop(lr=0.01*learn_rate_mult)
-        else:
-            optimizer_fn = Adam(lr=0.1*learn_rate_mult)
+        optimizer_fn = _get_optimizer(optimizer, learn_rate_mult)
 
         # Compile model
         model.compile(
@@ -113,3 +93,60 @@ def create_lstm_pool_model(embedding_matrix,
         return model
 
     return wrap_model
+
+
+class LSTMBaseModel(KerasModel):
+    def __init__(self, param={}, **kwargs):
+        super(LSTMBaseModel, self).__init__(param, **kwargs)
+        self.name = "lstm_base"
+
+    def model(self):
+        embedding_matrix = self.get_embedding_matrix()
+        model = create_lstm_pool_model(embedding_matrix, **self.model_param)
+        return KerasClassifier(model,
+                               verbose=self.model_param.get("verbose", 0))
+
+    def default_param(self):
+        kwargs = {
+            "backwards": True,
+            "dropout": 0.4,
+            "optimizer": "rmsprop",
+            "max_sequence_length": 1000,
+            "lstm_out_width": 20,
+            "lstm_pool_size": 128,
+            "learn_rate_mult": 1.0,
+            "verbose": 1,
+            "batch_size": 32,
+            "epochs": 10,
+            "shuffle": False,
+            "class_weight_inc": 30.0
+        }
+        return kwargs
+
+    def full_hyper_space(self):
+        from hyperopt import hp
+        hyper_choices = {
+            "mdl_optimizer": ["sgd", "rmsprop", "adagrad", "adam", "nadam"]
+        }
+        hyper_space = {
+            "mdl_optimizer": hp.choice("mdl_optimizer",
+                                       hyper_choices["mdl_optimizer"]),
+            "mdl_dropout": hp.uniform("mdl_dropout", 0, 0.9),
+            "mdl_lstm_out_width": hp.quniform("mdl_lstm_out_width", 1, 50, 1),
+            "mdl_dense_width": hp.quniform("mdl_dense_width", 1, 200, 1),
+            "mdl_learn_rate_mult": hp.lognormal("mdl_learn_rate_mult", 0, 2)
+        }
+        return hyper_space, hyper_choices
+
+    def fit_param_names(self):
+        param_names = [
+            "batch_size", "epochs", "shuffle", "class_weight_inc", "verbose",
+        ]
+        return param_names
+
+    def model_param_names(self):
+        param_names = [
+            "backward", "dropout", "optimizer", "max_sequence_length",
+            "lstm_out_width", "lstm_pool_size", "learn_rate_mult", "verbose",
+        ]
+        return param_names

--- a/asreview/models/sklearn_models.py
+++ b/asreview/models/sklearn_models.py
@@ -9,6 +9,20 @@ from sklearn.feature_extraction.text import CountVectorizer
 from asreview.models.base import BaseModel
 
 
+class SKLearnModel(BaseModel):
+    def __init__(self, param={}, **kwargs):
+        super(SKLearnModel, self).__init__(param)
+        self.name = "sklearn"
+
+    def get_Xy(self, texts, labels):
+        text_clf = Pipeline([('vect', CountVectorizer()),
+                             ('tfidf', TfidfTransformer())])
+
+        X = text_clf.fit_transform(texts)
+        y = labels
+        return X, y
+
+
 def create_nb_model(*args, **kwargs):
     """Return callable NaiveBayes model.
 
@@ -30,12 +44,12 @@ def create_nb_model(*args, **kwargs):
 
 
 class NBModel(BaseModel):
-    def __init__(self, model_kwargs={}, **kwargs):
-        super(NBModel, self).__init__(model_kwargs)
+    def __init__(self, param={}, **kwargs):
+        super(NBModel, self).__init__(param, **kwargs)
         self.name = "nb"
 
-    def model(self, *args, **kwargs):
-        model = create_nb_model(*args, **self.model_kwargs, **kwargs)
+    def model(self):
+        model = create_nb_model(**self.model_param())
         return model
 
     def default_kwargs(self):
@@ -72,28 +86,21 @@ def create_svc_model(*args, gamma="scale", class_weight=None, **kwargs):
             1: class_weight,
         }
 
-    model = SVC(*args, gamma=gamma, class_weight=class_weight, probability=True, **kwargs)
+    model = SVC(*args, gamma=gamma, class_weight=class_weight,
+                probability=True, **kwargs)
     logging.debug(model)
 
     return model
 
 
-class SVCModel(BaseModel):
+class SVCModel(SKLearnModel):
     def __init__(self, param={}, random_state=None, **kwargs):
-        super(SVCModel, self).__init__(param)
+        super(SVCModel, self).__init__(param, **kwargs)
         self.param["random_state"] = random_state
         self.name = "svm"
 
-    def get_Xy(self, texts, labels):
-        text_clf = Pipeline([('vect', CountVectorizer()),
-                             ('tfidf', TfidfTransformer())])
-
-        X = text_clf.fit_transform(texts)
-        y = labels
-        return X, y
-
     def model(self):
-        model = create_svc_model(**self.param)
+        model = create_svc_model(**self.model_param())
         return model
 
     def default_param(self):

--- a/asreview/models/sklearn_models.py
+++ b/asreview/models/sklearn_models.py
@@ -2,6 +2,8 @@ import logging
 
 from sklearn.naive_bayes import MultinomialNB
 from sklearn.svm import SVC
+from abc import ABC, abstractmethod
+from asreview.utils import _unsafe_dict_update
 
 
 def create_nb_model():
@@ -24,7 +26,7 @@ def create_nb_model():
     return model
 
 
-def create_svc_model(*args, gamma="scale", **kwargs):
+def create_svc_model(*args, gamma="scale", class_weight=None, **kwargs):
     """Return callable SVM model.
 
     Arguments
@@ -37,7 +39,88 @@ def create_svc_model(*args, gamma="scale", **kwargs):
         called.
 
     """
-    model = SVC(*args, gamma=gamma, probability=True, **kwargs)
+    if class_weight is not None:
+        class_weight = {
+            0: 1,
+            1: class_weight,
+        }
+
+    model = SVC(*args, gamma=gamma, class_weight=class_weight, probability=True, **kwargs)
     logging.debug(model)
 
     return model
+
+
+class BaseModel(ABC):
+    def __init__(self, model_kwargs):
+        self.name = "base"
+        self.model_kwargs = self.default_kwargs()
+        self.model_kwargs = _unsafe_dict_update(self.model_kwargs, model_kwargs)
+
+    def model_kwargs(self):
+        return self.model(), self.model_kwargs
+
+    @abstractmethod
+    def model(self):
+        raise NotImplementedError
+
+    def default_kwargs(self):
+        return {}
+
+    def full_hyper_space(self):
+        return {}, {}
+
+    def hyper_space(self, exclude=[], **kwargs):
+        from hyperopt import hp
+        hyper_space, hyper_choices = self.full_hyper_space()
+
+        for hyper_par in exclude:
+            hyper_space.pop(self._full(hyper_par), None)
+            hyper_choices.pop(self._full(hyper_par), None)
+
+        for hyper_par in kwargs:
+            full_hyper = self._full(hyper_par)
+            hyper_val = kwargs[hyper_par]
+            hyper_space[full_hyper] = hp.choice(full_hyper, [hyper_val])
+            hyper_choices[full_hyper] = [hyper_val]
+        return hyper_space, hyper_choices
+
+    def _full(self, par):
+        return "mdl_" + par
+
+    def _small(self, par):
+        return par[4:]
+
+
+class SVCModel(BaseModel):
+    def __init__(self, model_kwargs={}):
+        super(SVCModel, self).__init__(model_kwargs)
+        self.name = "svm"
+
+    def model(self, *args, **kwargs):
+        model = create_svc_model(*args, **self.model_kwargs, **kwargs)
+        return model
+
+    def default_kwargs(self):
+        kwargs = {
+            "gamma": "auto",
+            "class_weight": 0.249,
+            "C": 15.4,
+            "kernel": "sigmoid",
+        }
+        return kwargs
+
+    def full_hyper_space(self):
+        from hyperopt import hp
+        hyper_choices = {
+            "mdl_gamma": ["auto", "scale"],
+            "mdl_kernel": ["linear", "sigmoid", "rbf", "poly"]
+        }
+
+        hyper_space = {
+            "mdl_gamma": hp.choice('mdl_gamma', hyper_choices["mdl_gamma"]),
+            "mdl_kernel": hp.choice('mdl_kernel', hyper_choices["mdl_kernel"]),
+            "mdl_C": hp.lognormal('mdl_C', 0, 2),
+            "mdl_class_weight": hp.lognormal('mdl_class_weight', 0, 1)
+        }
+        return hyper_space, hyper_choices

--- a/asreview/models/sklearn_models.py
+++ b/asreview/models/sklearn_models.py
@@ -2,6 +2,9 @@ import logging
 
 from sklearn.naive_bayes import MultinomialNB
 from sklearn.svm import SVC
+from sklearn.pipeline import Pipeline
+from sklearn.feature_extraction.text import TfidfTransformer
+from sklearn.feature_extraction.text import CountVectorizer
 
 from asreview.models.base import BaseModel
 
@@ -80,6 +83,14 @@ class SVCModel(BaseModel):
         super(SVCModel, self).__init__(model_kwargs)
         self.model_kwargs["random_state"] = random_state
         self.name = "svm"
+
+    def get_Xy(self, texts, labels):
+        text_clf = Pipeline([('vect', CountVectorizer()),
+                             ('tfidf', TfidfTransformer())])
+
+        X = text_clf.fit_transform(texts)
+        y = labels
+        return X, y
 
     def model(self, *args, **kwargs):
         model = create_svc_model(*args, **self.model_kwargs, **kwargs)

--- a/asreview/models/sklearn_models.py
+++ b/asreview/models/sklearn_models.py
@@ -79,9 +79,9 @@ def create_svc_model(*args, gamma="scale", class_weight=None, **kwargs):
 
 
 class SVCModel(BaseModel):
-    def __init__(self, model_kwargs={}, random_state=None, **kwargs):
-        super(SVCModel, self).__init__(model_kwargs)
-        self.model_kwargs["random_state"] = random_state
+    def __init__(self, param={}, random_state=None, **kwargs):
+        super(SVCModel, self).__init__(param)
+        self.param["random_state"] = random_state
         self.name = "svm"
 
     def get_Xy(self, texts, labels):
@@ -93,7 +93,7 @@ class SVCModel(BaseModel):
         return X, y
 
     def model(self):
-        model = create_svc_model(**self.model_kwargs)
+        model = create_svc_model(**self.param)
         return model
 
     def default_param(self):

--- a/asreview/models/sklearn_models.py
+++ b/asreview/models/sklearn_models.py
@@ -43,7 +43,7 @@ def create_nb_model(*args, **kwargs):
     return model
 
 
-class NBModel(BaseModel):
+class NBModel(SKLearnModel):
     def __init__(self, param={}, **kwargs):
         super(NBModel, self).__init__(param, **kwargs)
         self.name = "nb"
@@ -52,7 +52,7 @@ class NBModel(BaseModel):
         model = create_nb_model(**self.model_param())
         return model
 
-    def default_kwargs(self):
+    def default_param(self):
         kwargs = {
             "alpha": 1.0,
         }

--- a/asreview/models/sklearn_models.py
+++ b/asreview/models/sklearn_models.py
@@ -79,7 +79,7 @@ def create_svc_model(*args, gamma="scale", class_weight=None, **kwargs):
 
 
 class SVCModel(BaseModel):
-    def __init__(self, model_kwargs={}, random_state=None):
+    def __init__(self, model_kwargs={}, random_state=None, **kwargs):
         super(SVCModel, self).__init__(model_kwargs)
         self.model_kwargs["random_state"] = random_state
         self.name = "svm"
@@ -92,11 +92,11 @@ class SVCModel(BaseModel):
         y = labels
         return X, y
 
-    def model(self, *args, **kwargs):
-        model = create_svc_model(*args, **self.model_kwargs, **kwargs)
+    def model(self):
+        model = create_svc_model(**self.model_kwargs)
         return model
 
-    def default_kwargs(self):
+    def default_param(self):
         kwargs = {
             "gamma": "auto",
             "class_weight": 0.249,

--- a/asreview/models/utils.py
+++ b/asreview/models/utils.py
@@ -1,12 +1,13 @@
 from asreview.models.sklearn_models import SVCModel, NBModel
 from asreview.models.lstm_base import LSTMBaseModel
+from asreview.models.lstm_pool import LSTMPoolModel
 
 
 def get_model_class(model):
-    models = dict(
-        svm=SVCModel,
-        nb=NBModel,
-        lstm_base=LSTMBaseModel
-    )
+    models = {
+        "svm": SVCModel,
+        "nb": NBModel,
+        "lstm_base": LSTMBaseModel,
+        "lstm_pool": LSTMPoolModel,
+    }
     return models.get(model, None)
-

--- a/asreview/models/utils.py
+++ b/asreview/models/utils.py
@@ -1,0 +1,12 @@
+from asreview.models.sklearn_models import SVCModel, NBModel
+from asreview.models.lstm_base import LSTMBaseModel
+
+
+def get_model_class(model):
+    models = dict(
+        svm=SVCModel,
+        nb=NBModel,
+        lstm_base=LSTMBaseModel
+    )
+    return models.get(model, None)
+

--- a/asreview/query_strategies/rand_max.py
+++ b/asreview/query_strategies/rand_max.py
@@ -6,11 +6,12 @@ Created on 9 Apr 2019
 from math import floor
 from typing import Tuple
 
+from modAL.utils.data import modALinput
 import numpy as np
+from sklearn.base import BaseEstimator
+
 from asreview.query_strategies.max_sampling import max_sampling
 from asreview.query_strategies.random_sampling import random_sampling
-from modAL.utils.data import modALinput
-from sklearn.base import BaseEstimator
 
 
 def rand_max_sampling(classifier: BaseEstimator,

--- a/asreview/review/base.py
+++ b/asreview/review/base.py
@@ -74,7 +74,7 @@ class BaseReview(ABC):
 
         self.model = model
         self.query_strategy = query_strategy
-        self.train_data = train_data_fn
+        self.balance_strategy = train_data_fn
 
         self.n_papers = n_papers
         self.n_instances = n_instances
@@ -348,7 +348,7 @@ class BaseReview(ABC):
             return
 
         # Get the training data.
-        X_train, y_train = self.train_data(
+        X_train, y_train = self.balance_strategy(
             self.X, self.y, self.train_idx, **self.balance_kwargs)
 
         # Train the model on the training data.

--- a/asreview/review/factory.py
+++ b/asreview/review/factory.py
@@ -38,6 +38,7 @@ def get_reviewer(dataset,
                  prior_excluded=None,
                  n_prior_included=DEFAULT_N_PRIOR_INCLUDED,
                  n_prior_excluded=DEFAULT_N_PRIOR_EXCLUDED,
+                 save_freq=1,
                  config_file=None,
                  src_log_fp=None,
                  model_param=None,
@@ -119,6 +120,7 @@ def get_reviewer(dataset,
             balance_kwargs=settings.balance_kwargs,
             query_kwargs=settings.query_kwargs,
             logger=logger,
+            save_freq=save_freq,
             **kwargs)
     elif mode == "oracle":
         reviewer = ReviewOracle(

--- a/asreview/review/factory.py
+++ b/asreview/review/factory.py
@@ -88,8 +88,7 @@ def get_reviewer(dataset,
     _, texts, labels = as_data.get_data()
 
     model_class = get_model_class(model)
-    model_inst = model_class(model_param=settings.model_param,
-                             fit_param=settings.fit_param,
+    model_inst = model_class(param=settings.model_param,
                              embedding_fp=embedding_fp)
     X, y = model_inst.get_Xy(texts, labels)
 

--- a/asreview/review/factory.py
+++ b/asreview/review/factory.py
@@ -121,7 +121,7 @@ def get_reviewer(dataset,
             balance_kwargs=settings.balance_kwargs,
             query_kwargs=settings.query_kwargs,
             logger=logger,
-            save_freq=save_freq,
+            save_freq=settings.save_freq,
             **kwargs)
     elif mode == "oracle":
         reviewer = ReviewOracle(

--- a/asreview/review/factory.py
+++ b/asreview/review/factory.py
@@ -15,13 +15,13 @@ from asreview.config import DEFAULT_QUERY_STRATEGY
 from asreview.config import DEMO_DATASETS
 from asreview.config import KERAS_MODELS
 from asreview.logging import Logger
+from asreview.models.utils import get_model_class
 from asreview.query_strategies.base import get_query_with_settings
 from asreview.readers import ASReviewData
 from asreview.review.minimal import MinimalReview
 from asreview.review.oracle import ReviewOracle
 from asreview.review.simulate import ReviewSimulate
 from asreview.settings import ASReviewSettings
-from asreview.models.utils import get_model_class
 
 
 def get_reviewer(dataset,

--- a/asreview/review/factory.py
+++ b/asreview/review/factory.py
@@ -1,10 +1,7 @@
 import json
 import logging
 import os
-import pickle
-import time
 from os.path import splitext
-from pathlib import Path
 
 from asreview.balance_strategies import get_balance_strategy
 from asreview.config import AVAILABLE_CLI_MODI

--- a/asreview/review/factory.py
+++ b/asreview/review/factory.py
@@ -63,7 +63,8 @@ def get_reviewer(dataset,
             model=model, n_instances=n_instances, n_queries=n_queries,
             n_papers=n_papers, n_prior_included=n_prior_included,
             n_prior_excluded=n_prior_excluded, query_strategy=query_strategy,
-            balance_strategy=balance_strategy, mode=mode, data_fp=dataset)
+            balance_strategy=balance_strategy, mode=mode, data_fp=dataset,
+            save_freq=save_freq)
 
         settings.from_file(config_file)
     if model_param is not None:

--- a/asreview/review/oracle.py
+++ b/asreview/review/oracle.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from asreview.ascii import ASCII_TEA
 from asreview.config import NOT_AVAILABLE
 from asreview.review import BaseReview

--- a/asreview/review/oracle.py
+++ b/asreview/review/oracle.py
@@ -16,6 +16,7 @@ def update_stats(stats, label):
     stats["n_reviewed"] += 1
     stats["n_pool"] -= 1
 
+
 class ReviewOracle(BaseReview):
     """ Review class for Oracle mode on the command line. """
 

--- a/asreview/settings.py
+++ b/asreview/settings.py
@@ -14,6 +14,7 @@ SETTINGS_TYPE_DICT = {
     "n_queries": int,
     "n_prior_included": int,
     "n_prior_excluded": int,
+    "save_freq": int,
     "mode": str,
     "model_param": dict,
     "query_param": dict,
@@ -29,6 +30,7 @@ class ASReviewSettings(object):
     def __init__(self, mode, model, query_strategy, balance_strategy,
                  n_instances=DEFAULT_N_INSTANCES, n_queries=None,
                  n_papers=None, n_prior_included=None, n_prior_excluded=None,
+                 save_freq=1,
                  data_fp=None, data_name=None, model_param={},
                  query_param={}, balance_param={}, **kwargs
                  ):

--- a/asreview/settings.py
+++ b/asreview/settings.py
@@ -66,6 +66,7 @@ class ASReviewSettings(object):
             return
 
         config = ConfigParser()
+        config.optionxform = str
         config.read(config_file)
 
         # Read the each of the sections.

--- a/asreview/settings.py
+++ b/asreview/settings.py
@@ -16,7 +16,6 @@ SETTINGS_TYPE_DICT = {
     "n_prior_excluded": int,
     "mode": str,
     "model_param": dict,
-    "fit_param": dict,
     "query_param": dict,
     "balance_param": dict,
 }
@@ -30,7 +29,7 @@ class ASReviewSettings(object):
     def __init__(self, mode, model, query_strategy, balance_strategy,
                  n_instances=DEFAULT_N_INSTANCES, n_queries=None,
                  n_papers=None, n_prior_included=None, n_prior_excluded=None,
-                 data_fp=None, data_name=None, model_param={}, fit_param={},
+                 data_fp=None, data_name=None, model_param={},
                  query_param={}, balance_param={}, **kwargs
                  ):
         all_args = locals().copy()
@@ -79,8 +78,7 @@ class ASReviewSettings(object):
                         print(f"Warning: value with key '{key}' is ignored "
                               "(spelling mistake, wrong type?).")
 
-            elif sect in ["model_param", "fit_param", "query_param",
-                          "balance_param"]:
+            elif sect in ["model_param", "query_param", "balance_param"]:
                 setattr(self, sect, dict(config.items(sect)))
             elif sect != "DEFAULT":
                 print (f"Warning: section [{sect}] is ignored in "

--- a/asreview/utils.py
+++ b/asreview/utils.py
@@ -189,11 +189,12 @@ def clear_data_home(data_home=None):
     shutil.rmtree(data_home)
 
 
-def _set_class_weight(weight1, fit_kwargs):
+def _set_class_weight(weight1):
     """ Used in RNN's to have quicker learning. """
     weight0 = 1.0
-    fit_kwargs['class_weight'] = {
+    cw_class = {
         0: weight0,
         1: weight1,
     }
     logging.debug(f"Using class weights: 0 <- {weight0}, 1 <- {weight1}")
+    return cw_class


### PR DESCRIPTION
Add hyperopt to ASReview core, for easier hyperparameter searches.

The actual code to run the hyperparameter search is in the simulation project (branch). 

Adds support for all balance strategies and models currently in core. 

Rewrites the way different models are handled:
- Everything model specific is removed from the review package and moved into the models package.
- Models are now classes (you can theoretically do without, but it would be a hassle).
- Hyperparameter package hyperopt is optional. You can define a new model without providing the necessary hooks (and it would still work). The asreview package works without having hyperopt installed.
- Add an option to skip saving every x training steps. [This might be removed after implementing a better data/save model.]
resolves #7 