### PR TITLE
Add CI workflow for Github Actions

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,0 +1,19 @@
+name: test-suite
+on: [push, pull_request]
+jobs:
+  test:
+    name: pytest
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.6' # Version range or exact version of a Python version to use, using semvers version range syntax.
+        architecture: 'x64' # (x64 or x86)
+    - name: Install packages and run tests  
+      run: |
+        pip install pytest
+        pip install --upgrade setuptools>=41.0.0
+        pip install .
+        pytest
+     


### PR DESCRIPTION
This pull request adds a CI workflow with Github Actions. Tests pass in my fork (see [here](https://github.com/jelletreep/automated-systematic-review/commit/d06889d634cc5091585b6de9efdd1dadec9eba93/checks?check_suite_id=310926471)). I think it is ready for merging.

I will create a separate pull-request to remove travis and add a Github Actions badge in the README that can be merged when Github Actions performs satisfactory. 