### PR TITLE
Require Python version 3.6 or higher.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
     ],
     keywords='systematic review',
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
+    python_requires='~=3.6',
     install_requires=[
         'numpy',
         'tensorflow',


### PR DESCRIPTION
Don't commit to 4.0 yet.

Resolves #131 